### PR TITLE
Don't require cloning/forking the endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
 # Beakermentions Endpoint
 
-[Beakermentions Endpoint][1] is an endpoint implementation of the [W3C][2] [Webmention][3] recommendation for [Beaker Browser][4] users. Webmentions are a simple way to notify any URL when you mention it from another URL. This implementation utilizes Beaker Browser's [`hyperdrive`][5] and [`peersockets`][6] API. Deviations exist from the official recommendation due to the unique environment Beaker Browser provides:
+[Beakermentions Endpoint][1] is an endpoint implementation of the [W3C][2] [Webmention][3] recommendation for [Beaker Browser][4] users. Webmentions are a simple way to notify any URL when you mention it from another URL. This implementation utilizes Beaker Browser's [`hyperdrive`][5] and [`peersockets`][6] API. Deviations exist from the official recommendation due to the environment Beaker Browser provides:
 
-* The `source` may reference the `target` URL of the Webmention through the file's metadata keys (like `@inReplyTo`, `@likeOf`, `@rsvpTo`, etc.) in addition to the file's content.
+* The `source` may reference the `target` URL of the Webmention through the file's metadata keys (like `inReplyTo`, `likeOf`, `rsvpTo`, etc.) in addition to the file's content.
 
-* The sender may look for a metadata key `@webmention` in the `target`'s URL to discover the `target`'s Beakermentions Endpoint in addition to the sender looking for an HTTP link header, a `<link>` element, or an `<a>` element with a `@rel` value of "webmention."
+* The sender may look for a metadata key `webmention` in the `target`'s URL to discover the `target`'s Beakermentions Endpoint in addition to the sender looking for an HTTP link header, a `<link>` element, or an `<a>` element with a `rel` attribute value of "webmention."
 
 * Communication between the users and the Beakermentions Endpoint are done through [Location][9] search strings and `beaker.peersockets` instead of HTTP POST.
 
 Mentions are not limited to HTML; any file can mention any other file using metadata key-value pairs.
 
-Do note that this is only an endpoint implementation; an endpoint only stores and provides the `source` URLs that mention a particular `target` URL. Any rendering of mentions (including which mentions to render) is done by an application itself after retrieving a `target`'s `sources`.
+Do note that this is only an endpoint implementation; an endpoint only saves `source` URLs that mention a particular `target` URL to a `.webmention` file in the `target`'s drive. Any rendering of mentions (including which mentions to render) is done by an application itself after retrieving a `target`'s `sources`.
 
 ## How This Works
 
 1. Alice writes a new file and saves it to `hyper://alice/microblog/a-good-day.md`.
 
-2. Alice adds a `@webmention` metadata key to the new file with a value of their Beakermentions Endpoint: `hyper://alice-beakermentions/`
+2. Alice adds a `webmention` metadata key to the new file with a value of their Beakermentions Endpoint: `hyper://alice-beakermentions/`
 
 3. Alice opens their Beakermentions Endpoint so it's listening for new sent mentions, then minimizes it to the background.
 
-4. Bob sees Alice's new file and wants to tell Alice that they like it! They write a new file in response, add their own `@webmention` key in the metadata so others can respond to it, add a `@likeOf` key with a value of Alice's file URL, and saves their response to `hyper://bob/microblog/that-is-good.md`.
+4. Bob sees Alice's new file and wants to tell Alice that they like it! They write a new file in response, add their own `webmention` key in the metadata so others can respond to it, add a `likeOf` key with a value of Alice's file URL, and saves their response to `hyper://bob/microblog/that-is-good.md`.
 
 5. Bob's application notices that the file they're saving mentions Alice's file. After saving, it offers to bring Bob to Alice's Beakermentions Endpoint's page to automatically send the mention: `hyper://alice-beakermentions/?source=hyper://bob/microblog/that-is-good.md&target=hyper://alice/microblog/a-good-day.md&done=hyper://bob/`.
 
-6. Alice's Beakermentions Endpoint verifies that Alice wants their file mentioned by checking that their file's `@webmention` key is the Beakermention Endpoint's URL, then checks Bob's file to make sure that they mention Alice's file URL in its metadata or in its content.
+6. Alice's Beakermentions Endpoint verifies that Alice wants their file mentioned by checking that their file's `webmention` key is the Beakermention Endpoint's URL, then checks Bob's file to make sure that they mention Alice's file URL in its metadata or in its content.
 
-7. After verification, Alice's Beakermentions Endpoint stores the mention in `hyper://alice-beakermentions/mentions/hyper/alice/microblog/a-good-day.md.json`, then sends Bob a success message. At this point, the endpoint may send Bob back to `hyper://bob/`.
+7. After verification, Alice's Beakermentions Endpoint stores the mention in `hyper://alice/microblog/a-good-day.md.webmention`, then sends Bob a success message. At this point, the endpoint may send Bob back to `hyper://bob/`.
 
 As an alternative to step 5, Bob may interactively send the webmention (instead of their application) by visiting Alice's Beakermention Endpoint, entering their response as the source and Alice's file as the target, and pressing send.
 
-Now, when an application opens Alice's file, they may notice the `@webmention` key in the metadata. They may get all the stored mentions from the Beakermentions Endpoint by reading `hyper://alice-beakermentions/mentions/hyper/alice/microblog/a-good-day.md.json` and display whichever mentions they want to present by processing each URL.
+Now, when an application opens Alice's file, they may notice the `webmention` key in the metadata. They may get all the stored mentions from the Beakermentions Endpoint by reading `hyper://alice/microblog/a-good-day.md.webmention` and display whichever mentions they want to present by processing each URL.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -42,14 +42,14 @@
             </p>
             <p>
               <label for="blacklist">Source Blacklist (one URL/line)</label>
-              <textarea id="blacklist" disabled="disabled"></textarea>
+              <textarea id="blacklist"></textarea>
             </p>
             <p>
               <label for="whitelist">Target Whitelist (one URL/line)</label>
-              <textarea id="whitelist" disabled="disabled"></textarea>
+              <textarea id="whitelist"></textarea>
             </p>
             <p>
-              <button id="save-configuration" disabled="disabled">Save Configuration</button>
+              <button id="save-configuration">Save Configuration</button>
             </p>
           </div>
         </details>

--- a/index.html
+++ b/index.html
@@ -35,17 +35,17 @@
           <summary>Configure Endpoint</summary>
           <div id="configure-endpoint">
             <p>
-              <label for="endpoint">Endpoint URL (<code>@webmention</code>)</label>
+              <label for="endpoint">Endpoint URL (use this for the <code>webmention</code> key)</label>
               <input id="endpoint"
                      type="text"
                      disabled="disabled"></input>
             </p>
             <p>
-              <label for="blacklist">Source Blacklist (one Drive URL/line)</label>
+              <label for="blacklist">Source Blacklist (one hyperdrive URL/line)</label>
               <textarea id="blacklist"></textarea>
             </p>
             <p>
-              <label for="whitelist">Target Whitelist (one Drive URL/line)</label>
+              <label for="whitelist">Target Whitelist (one hyperdrive URL/line)</label>
               <textarea id="whitelist"></textarea>
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -41,11 +41,11 @@
                      disabled="disabled"></input>
             </p>
             <p>
-              <label for="blacklist">Source Blacklist (one URL/line)</label>
+              <label for="blacklist">Source Blacklist (one Drive URL/line)</label>
               <textarea id="blacklist"></textarea>
             </p>
             <p>
-              <label for="whitelist">Target Whitelist (one URL/line)</label>
+              <label for="whitelist">Target Whitelist (one Drive URL/line)</label>
               <textarea id="whitelist"></textarea>
             </p>
             <p>

--- a/index.js
+++ b/index.js
@@ -16,30 +16,23 @@ let Endpoint;
 
 async function main() {
   // Initialize the environment
-  Endpoint = new BeakermentionsEndpoint(`${location.protocol}//${location.host}${location.pathname}`);
+  Endpoint = new BeakermentionsEndpoint(location.href, window.localStorage);
   document.getElementById("endpoint").value = Endpoint.endpoint;
   let params = new URLSearchParams(document.location.search.substring(1));
   console.debug("index.main: Grabbed variables from the environment");
   loadREADME();
 
   // Initialize the endpoint and its event handlers
-  Endpoint.onResponseSet(response => {
-    updatePageResponse(response);
-  });
+  Endpoint.onResponseSet(response => { updatePageResponse(response); });
   console.debug("index.main: Added Endpoint.onResponseSet event handler.");
-  Endpoint.onBlacklistLoaded(blacklist => {
-    document.getElementById("blacklist").value = blacklist.join("\n");
-  });
+  Endpoint.onBlacklistLoaded(blacklist => { document.getElementById("blacklist").value = blacklist.join("\n"); });
   console.debug("index.main: Added Endpoint.onBlacklistLoaded event handler.");
-  Endpoint.onWhitelistLoaded(whitelist => {
-    document.getElementById("whitelist").value = whitelist.join("\n");
-  });
+  Endpoint.onWhitelistLoaded(whitelist => { document.getElementById("whitelist").value = whitelist.join("\n"); });
   console.debug("index.main: Added Endpoint.onWhitelistLoaded event handler.");
+  document.getElementById("save-configuration").addEventListener("click", saveConfiguration);
   await Endpoint.init();
-  if (Endpoint.hyperdriveWritable) {
-    enableConfigurationSaving();
-  }
   console.debug("index.main: Endpoint is ready.");
+
   let sendMode = params.get("source") && params.get("target");
   if (sendMode) {
     Endpoint.source = params.get("source");
@@ -58,15 +51,6 @@ async function main() {
 async function loadREADME() {
   let readme = await beaker.hyperdrive.readFile("/README.md", "utf8");
   document.getElementById("readme").innerHTML = beaker.markdown.toHTML(readme);
-}
-
-// Enable Configuration Saving
-function enableConfigurationSaving() {
-  document.getElementById("blacklist").removeAttribute("disabled");
-  document.getElementById("whitelist").removeAttribute("disabled");
-  document.getElementById("save-configuration").removeAttribute("disabled");
-  document.getElementById("save-configuration").addEventListener("click", saveConfiguration);
-  console.debug("index.enableConfigurationSaving: Enabled configuration saving.");
 }
 
 // Call the Endpoint to save the configuration

--- a/index.js
+++ b/index.js
@@ -40,10 +40,7 @@ async function main() {
     Endpoint.target = params.get("target");
     document.getElementById("send-webmention-target").value = Endpoint.target;
     if (params.get("done")) { Endpoint.done = params.get("done"); }
-    if (Endpoint.hyperdriveWritable) {
-      console.debug("index.main: Try directly sending a webmention.");
-      Endpoint.sendWebmention();
-    }
+    Endpoint.sendWebmention();
   }
 }
 

--- a/modules/BeakermentionsEndpoint.js
+++ b/modules/BeakermentionsEndpoint.js
@@ -46,6 +46,7 @@ export class BeakermentionsEndpoint {
   #response;
   get response() { return this.#response; }
   set response(response) {
+    clearTimeout(this.#responseTimeout);
     this.#response = response;
     this.responseSet(response);
   }
@@ -53,6 +54,7 @@ export class BeakermentionsEndpoint {
   onResponseSet(eventHandler) {
     this.responseSet = eventHandler;
   }
+  #responseTimeout;
 
   #endpoint;
   get endpoint() { return this.#endpoint; }
@@ -109,6 +111,9 @@ export class BeakermentionsEndpoint {
       for (let peer of this.#peers) {
         this.#sendJSONMessage(Messages.visitorIdentityMessage(this.#getHash(this.target)), peer);
       }
+      this.#responseTimeout = setTimeout(() => {
+        this.response = Messages.failMessage(this.source, this.target, "No peers around that can reply to this webmention.");
+      }, 60000);
     }
   }
 

--- a/modules/BeakermentionsEndpoint.js
+++ b/modules/BeakermentionsEndpoint.js
@@ -112,9 +112,18 @@ export class BeakermentionsEndpoint {
     }
   }
 
-  saveConfigurationFile() {
+  async saveConfigurationFile() {
     this.#storage.setItem("blacklist", JSON.stringify(this.blacklist));
     this.#storage.setItem("whitelist", JSON.stringify(this.whitelist));
+
+    // Save and delete a temporary file in each whitelisted drive to ask for write permissions.
+    for (let i = 1; i < this.#whitelist.length; i++) {
+      const hyperdrive = beaker.hyperdrive.drive(this.#whitelist[i]);
+      await hyperdrive.writeFile("/tmp-beakermentions", "", "utf8");
+      await hyperdrive.unlink("/tmp-beakermentions");
+    }
+
+    console.debug("BeakermentionsEndpoint.saveConfigurationFile: Configuration saved to local storage.");
   }
 
   /********** Private Methods **********/

--- a/modules/BeakermentionsEndpoint.js
+++ b/modules/BeakermentionsEndpoint.js
@@ -239,9 +239,7 @@ export class BeakermentionsEndpoint {
   
     try {
       // Create and initialize an instance of MentionFilestore
-      let filePath = "/mentions/" + target;
-      filePath = filePath.replace("://", "/");
-      let file = new MentionFilestore(filePath + ".json");
+      let file = new MentionFilestore(`${target}.webmention`);
       await file.init();
   
       // Check to see if the target is valid

--- a/modules/BeakermentionsEndpoint.js
+++ b/modules/BeakermentionsEndpoint.js
@@ -167,7 +167,8 @@ export class BeakermentionsEndpoint {
       const message = this.#receiveJSONMessage(e);
       switch(message.type) {
         case "visitor":
-          if (this.#checkHashAgainstWhitelist(message.hash)) {
+          const hashInList = await this.#checkHashAgainstWhitelist(message.hash);
+          if (hashInList) {
             const reply = Messages.endpointIdentityMessage();
             this.#sendJSONMessage(reply, e.peerId);
             console.debug("BeakermentionsEndpoint: Visitor message has whitelisted hash; sending Endpoint message.");

--- a/modules/MentionFilestore.js
+++ b/modules/MentionFilestore.js
@@ -18,7 +18,9 @@ export class MentionFilestore {
   /********** Constructor **********/
 
   constructor(path) {
-    this.#path = path;
+    const url = new URL(path);
+    this.#thisHyperdrive = beaker.hyperdrive.drive(`hyper://${url.hostname}/`);
+    this.#path = url.pathname;
   }
 
   /********** Public Methods **********/
@@ -27,7 +29,6 @@ export class MentionFilestore {
   async init() {
     let file = [];
     try {
-      this.#thisHyperdrive = beaker.hyperdrive.drive("/");
       let fileString = await this.#thisHyperdrive.readFile(this.#path, "utf8");
       file = JSON.parse(fileString);
     } catch (error) {

--- a/modules/Messages.js
+++ b/modules/Messages.js
@@ -18,9 +18,10 @@ export function endpointIdentityMessage() {
   return message;
 }
 
-export function visitorIdentityMessage() {
+export function visitorIdentityMessage(hash) {
   let message = {
-    "type" : "visitor"
+    "type" : "visitor",
+    "hash" : hash
   };
   return message;
 }


### PR DESCRIPTION
- [X] Save user configuration to `Window.localStorage` instead of a configuration file.
- [x] Save Beakermentions to `hyper://hash/path/to/URL.webmention` instead of the drive's `/mentions/`.
- [x] Create/use a hash function that is compatible with being used in a CC0-licensed project
- [x] All users trying to send Beakermentions will still send the `visitor` message via `beaker.peersockets`, but with an additional hash of the URL's drive. Since the `visitor` message is currently sent to all connected peers, this will help keep the hash hidden except for the users who need it:
```
let visitorMessage = {
  "type" : "visitor",
  "target" : "[hash of discovery/public key of a hyperdrive]"
};
```
- [x] All users wanting to receive Beakermentions _must_ put their drives in the configuration's whitelist. They will compare the received hashes with their whitelisted drive URLs and send an `endpoint` message if and only if the hash matches. The `endpoint` message will not change.
- [x] All applications that consume Beakermentions from this endpoint _must_ read them from `hyper://hash/path/to/URL.webmention` instead of the drive's `/mentions/` directory

---

### Additional Tasks

- [x] Implement a timeout after a visitor message is sent; this will be important for sending window messages later for an app that sends webmentions.
- [x] Create a function to write and delete a temporary file in each whitelisted drive to allow writes to drives in the future.

---

Closes #4 